### PR TITLE
tweak concurrent.go

### DIFF
--- a/presentation/concurrent.go
+++ b/presentation/concurrent.go
@@ -1,12 +1,16 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 func main() {
 	messages := make(chan string)
 	go func() { 
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 100; i++ {
 			messages <- fmt.Sprintf("ping%d", i)
+			time.Sleep(100 * time.Millisecond)
 		}
 		close(messages)
 	}()


### PR DESCRIPTION
Could add a sleep and higher loop range to make the demo clearer that the goroutine is async.
